### PR TITLE
Load theories on demand

### DIFF
--- a/libisabelle/src/main/scala/System.scala
+++ b/libisabelle/src/main/scala/System.scala
@@ -22,6 +22,7 @@ object System {
   // implementation details
 
   private val ID = "id"
+  private val USE_THEORIES_RESULT = "use_theories_result"
   private val LIBISABELLE_RESPONSE = "libisabelle_response"
 
   private object Libisabelle_Response {
@@ -29,6 +30,15 @@ object System {
       case
         (Markup.FUNCTION, LIBISABELLE_RESPONSE) ::
         (ID, Properties.Value.Long(id)) :: Nil => Some(id)
+      case _ => None
+    }
+  }
+
+  private object Use_Theories_Result {
+    def unapply(props: Properties.T): Option[Long] = props match {
+      case
+        (Markup.FUNCTION, USE_THEORIES_RESULT) ::
+        (ID, Properties.Value.Long(id)) :: _ => Some(id)
       case _ => None
     }
   }
@@ -79,6 +89,7 @@ class System private(options: Options, session: Session, root: Path)(implicit ec
     case msg: Prover.Protocol_Output =>
       (msg.properties match {
         case System.Libisabelle_Response(id) => Some(id)
+        case System.Use_Theories_Result(id) => Some(id)
         case _ => None
       }) foreach { id =>
         self.synchronized {
@@ -103,6 +114,19 @@ class System private(options: Options, session: Session, root: Path)(implicit ec
     count += 1
     promise.future
   }
+
+  private val Ok = new Properties.Boolean("ok")
+
+  def loadTheories(thys: java.io.File*): Future[Boolean] =
+    withRequest {
+      val args = count.toString +: root.implode +: thys.map(_.getPath())
+      session.protocol_command("use_theories", args: _*)
+    } flatMap { msg =>
+      Future.fromTry(msg.properties match {
+        case Ok(ok) => Success(ok)
+        case _ => Failure(System.ProverException("prover returned malformed message", msg.body))
+      })
+    }
 
 
   def invoke[I, O](operation: Operation[I, O])(arg: I): Future[Result[O]] =

--- a/libisabelle/src/main/scala/japi/System.scala
+++ b/libisabelle/src/main/scala/japi/System.scala
@@ -38,4 +38,7 @@ class JSystem private(system: System, timeout: Duration) {
       case Right(v) => v
     }
 
+  def loadTheories(thys: java.util.List[java.io.File]): Boolean =
+    await(system.loadTheories(thys.asScala: _*))
+
 }

--- a/libisabelle/src/test/isabelle/Test.thy
+++ b/libisabelle/src/test/isabelle/Test.thy
@@ -1,0 +1,17 @@
+theory Test
+imports Protocol
+begin
+
+operation_setup type_of = \<open>
+  let
+    val ctxt = Config.put show_markup false @{context}
+    val read = Print_Mode.setmp []
+      (Syntax.read_term @{context} #> fastype_of #> Syntax.string_of_typ ctxt)
+  in
+    {from_lib = Codec.string,
+     to_lib = Codec.string,
+     action = read}
+  end
+\<close>
+
+end

--- a/libisabelle/src/test/scala/LibisabelleSpec.scala
+++ b/libisabelle/src/test/scala/LibisabelleSpec.scala
@@ -13,20 +13,25 @@ class LibisabelleSpec extends Specification with NoTimeConversions { def is = s2
   Basic protocol interaction
 
   An Isabelle session
-    can be started        $start
-    reacts to requests    $req
-    can be torn down      $stop"""
+    can be started          $start
+    can load theories       $load
+    reacts to requests      $req
+    can be torn down        $stop"""
 
+
+  val TypeOf = Operation.implicitly[String, String]("type_of")
 
   val system = System.instance(Some(new java.io.File(".")), "Protocol")
-  val response = system.flatMap(_.invoke(Operation.Hello)("world"))
+  val loaded = system.flatMap(_.loadTheories(new java.io.File("libisabelle/src/test/isabelle/Test")))
+  val response = for { s <- system; _ <- loaded; res <- s.invoke(TypeOf)("op ==>") } yield res
   val teardown = for { s <- system; _ <- response /* wait for response */; _ <- s.dispose } yield ()
 
   def exist[A]: Matcher[A] = ((a: A) => a != null, "doesn't exist")
 
 
   def start = system must exist.await(timeout = 30.seconds)
-  def req = response must beRight("Hello world").await(timeout = 30.seconds)
+  def load = loaded must beTrue.await(timeout = 30.seconds)
+  def req = response must beRight("prop => prop => prop").await(timeout = 30.seconds)
   def stop = teardown must exist.await(timeout = 30.seconds)
 
 }


### PR DESCRIPTION
Reuses the built-in `use_theories` protocol command. Might replace it with a `libisabelle` operation in the future.
