### PR TITLE
Enhanced management of operations

### DIFF
--- a/libisabelle/src/main/isabelle/Protocol/Protocol.thy
+++ b/libisabelle/src/main/isabelle/Protocol/Protocol.thy
@@ -11,8 +11,12 @@ signature LIBISABELLE = sig
      to_lib : 'o codec,
      action : 'i -> 'o}
 
-  val add_operation : name -> ('i, 'o) operation -> unit
-  val operation_setup : bstring -> Symbol_Pos.source -> theory -> unit
+  type flags = {sequential: bool, bracket: bool}
+
+  val default_flags : flags
+
+  val add_operation : name -> ('i, 'o) operation -> flags -> unit
+  val operation_setup : bstring -> Symbol_Pos.source -> flags -> theory -> unit
 end
 
 structure Libisabelle : LIBISABELLE = struct
@@ -23,35 +27,61 @@ type ('i, 'o) operation =
    to_lib : 'o codec,
    action : 'i -> 'o}
 
-type raw_operation = XML.tree -> XML.tree
+type flags = {sequential: bool, bracket: bool}
+
+val default_flags = {sequential = false, bracket = false}
+
+fun join_flags
+  {sequential = seq1, bracket = br1}
+  {sequential = seq2, bracket = br2} =
+  {sequential = seq1 orelse seq2, bracket = br1 orelse br2}
+
+type raw_operation = int -> XML.tree -> XML.tree
 
 exception GENERIC of string
 
 val operations =
   Synchronized.var "libisabelle.operations" (Symtab.empty: raw_operation Symtab.table)
 
-fun add_operation name {from_lib, to_lib, action} =
+fun sequentialize name f =
   let
-    fun raw tree =
+    val var = Synchronized.var ("libisabelle." ^ name) ()
+  in
+    fn x => Synchronized.change_result var (fn _ => (f x, ()))
+  end
+
+fun bracketize f id x =
+  let
+    val start = [(Markup.functionN, "libisabelle_start"), ("id", Markup.print_int id)]
+    val stop = [(Markup.functionN, "libisabelle_stop"), ("id", Markup.print_int id)]
+    val _ = Output.protocol_message start []
+    val res = f id x
+    val _ = Output.protocol_message stop []
+  in res end
+
+fun add_operation name {from_lib, to_lib, action} {sequential, bracket} =
+  let
+    fun raw _ tree =
       case Codec.decode from_lib tree of
         Codec.Success i => Codec.encode to_lib (action i)
       | Codec.Failure (msg, _) => raise Fail ("decoding input failed " ^ msg)
+    val raw' = raw
+      |> (if sequential then sequentialize name else I)
+      |> (if bracket then bracketize else I)
   in
-    Synchronized.change operations (Symtab.update (name, raw))
+    Synchronized.change operations (Symtab.update (name, raw'))
   end
 
 val _ = Isabelle_Process.protocol_command "libisabelle"
   (fn id :: name :: [arg] =>
     let
       val id = Markup.parse_int id
-      val response =
-        [(Markup.functionN, "libisabelle_response"),
-         ("id", Markup.print_int id)]
+      val response = [(Markup.functionN, "libisabelle_response"), ("id", Markup.print_int id)]
       val args = YXML.parse arg
       fun exec f =
         (Future.fork (fn () =>
           let
-            val res = Exn.interruptible_capture f args
+            val res = Exn.interruptible_capture (f id) args
             val yxml = YXML.string_of (Codec.encode (Codec.exn_result Codec.id) res)
           in
             Output.protocol_message response [yxml]
@@ -63,17 +93,39 @@ val _ = Isabelle_Process.protocol_command "libisabelle"
       | NONE => exec (fn _ => raise Fail "libisabelle: unknown command"))
     end)
 
-fun operation_setup name source thy =
+fun print_bool true = "true"
+  | print_bool false = "false"
+
+fun print_flags {sequential, bracket} =
+  "({sequential=" ^ print_bool sequential ^ ",bracket=" ^ print_bool bracket ^ "})"
+
+fun operation_setup name source flags thy =
   ML_Context.eval_in (SOME (Proof_Context.init_global thy)) ML_Compiler.flags (#pos source)
     (ML_Lex.read Position.none ("Libisabelle.add_operation " ^ ML_Syntax.print_string name ^ "(") @
       ML_Lex.read_source false source @
-      ML_Lex.read Position.none ")")
+      ML_Lex.read Position.none ")" @
+      ML_Lex.read Position.none (print_flags flags))
+
+val _ =
+  let
+    val parse_flag =
+      (Parse.reserved "sequential" || Parse.reserved "bracket") >>
+        (fn flag => join_flags
+           {sequential = flag = "sequential",
+            bracket = flag = "bracket"})
+    val parse_flags =
+      Parse.list parse_flag >> (fn fs => fold (curry op o) fs I)
+    val parse_cmd =
+      Scan.optional (Args.parens parse_flags) I --
+      Parse.name --
+      Parse.!!! (@{keyword "="} |-- Parse.ML_source)
+  in
+    Outer_Syntax.command @{command_spec "operation_setup"} "define protocol operation in ML"
+      (parse_cmd >> (fn ((flags, name), txt) =>
+        Toplevel.theory (tap (operation_setup name txt (flags default_flags)))))
+  end
 
 end
-
-val _ = Outer_Syntax.command @{command_spec "operation_setup"} "define protocol operation in ML"
-  (Parse.name -- Parse.!!! (@{keyword "="} |-- Parse.ML_source)
-    >> (fn (name, txt) => Toplevel.theory (tap (Libisabelle.operation_setup name txt))))
 \<close>
 
 operation_setup hello = \<open>
@@ -81,7 +133,7 @@ operation_setup hello = \<open>
    to_lib = Codec.string,
    action = (fn data => "Hello " ^ data)}\<close>
 
-operation_setup use_thys = \<open>
+operation_setup (sequential, bracket) use_thys = \<open>
   {from_lib = Codec.list Codec.string,
    to_lib = Codec.unit,
    action = Thy_Info.use_thys o map (rpair Position.none)}\<close>

--- a/libisabelle/src/main/isabelle/Protocol/Protocol.thy
+++ b/libisabelle/src/main/isabelle/Protocol/Protocol.thy
@@ -66,8 +66,8 @@ fun add_operation name {from_lib, to_lib, action} {sequential, bracket} =
         Codec.Success i => Codec.encode to_lib (action i)
       | Codec.Failure (msg, _) => raise Fail ("decoding input failed " ^ msg)
     val raw' = raw
-      |> (if sequential then sequentialize name else I)
       |> (if bracket then bracketize else I)
+      |> (if sequential then sequentialize name else I)
   in
     Synchronized.change operations (Symtab.update (name, raw'))
   end

--- a/libisabelle/src/main/scala/Operation.scala
+++ b/libisabelle/src/main/scala/Operation.scala
@@ -4,23 +4,46 @@ import scala.collection.JavaConverters._
 
 import isabelle._
 
+sealed abstract class Observer[T]
+
+object Observer {
+
+  case class Success[T](t: Exn.Result[T]) extends Observer[T]
+  case class Failure[T](error: Exception) extends Observer[T]
+  case class More[T](step: Prover.Message => Observer[T], done: XML.Tree => Observer[T]) extends Observer[T]
+
+  def ignoreStep[T](done: XML.Tree => Observer[T]): Observer[T] = {
+    lazy val observer: Observer[T] = More(_ => observer, done)
+    observer
+  }
+
+  def decodeWith[O](fromProver: Codec[O])(tree: XML.Tree): Observer[O] =
+    Codec.exnResult(fromProver).decode(tree) match {
+      case Left((err, body)) => Observer.Failure(new DecodingException(err, body))
+      case Right(o) => Observer.Success(o)
+    }
+
+}
+
+
 object Operation {
 
   def implicitly[I : Codec, O : Codec](name: String): Operation[I, O] =
-    Operation(name, Codec[I], Codec[O])
+    simple(name, Codec[I], Codec[O])
 
   val Hello = implicitly[String, String]("hello")
   val UseThys = implicitly[List[String], Unit]("use_thys")
 
   protected[isabelle] val UseThys_Java =
-    Operation("use_thys",
+    Operation.simple("use_thys",
       Codec[List[String]].transform[java.util.List[String]](_.asJava, _.asScala.toList),
       Codec[Unit].transform[Void](_ => null, _ => ()))
 
+  def simple[I, O](name: String, toProver: Codec[I], fromProver: Codec[O]): Operation[I, O] =
+    Operation(name, toProver, Observer.ignoreStep[O](Observer.decodeWith(fromProver)))
+
 }
 
-case class Operation[I, O](name: String, toProver: Codec[I], fromProver: Codec[O]) {
+case class Operation[I, O](name: String, toProver: Codec[I], observer: Observer[O]) {
   def encode(i: I): XML.Tree = toProver.encode(i)
-  def decode(xml: XML.Tree): Result[O] =
-    Codec.exnResult(fromProver).decode(xml).right.map(Exn.release)
 }

--- a/libisabelle/src/main/scala/System.scala
+++ b/libisabelle/src/main/scala/System.scala
@@ -15,20 +15,6 @@ object System {
   }
 
 
-  // implementation details
-
-  private val ID = "id"
-  private val LIBISABELLE_RESPONSE = "libisabelle_response"
-
-  private object Libisabelle_Response {
-    def unapply(props: Properties.T): Option[Long] = props match {
-      case
-        (Markup.FUNCTION, LIBISABELLE_RESPONSE) ::
-        (ID, Properties.Value.Long(id)) :: Nil => Some(id)
-      case _ => None
-    }
-  }
-
   private def mkPhaseListener(session: Session, phase: Session.Phase)(implicit ec: ExecutionContext): Future[Unit] = {
     val promise = Promise[Unit]
     val consumer = Session.Consumer[Session.Phase]("phase-listener") {
@@ -65,15 +51,38 @@ object System {
   }
 
 
+  private class Output(name: String) {
+    def unapply(props: Properties.T): Option[Long] = props match {
+      case
+        (Markup.FUNCTION, `name`) ::
+        ("id", Properties.Value.Long(id)) :: Nil => Some(id)
+      case _ => None
+    }
+  }
+
+  private object Output {
+    object Response extends Output("libisabelle_response")
+    object Start extends Output("libisabelle_start")
+    object Stop extends Output("libisabelle_stop")
+  }
+
+
   private trait OperationState { self =>
     type T
-    val bracketed: Boolean
+    val firehose: Boolean
     val observer: Observer[T]
     val promise: Promise[Exn.Result[T]]
 
+    def withFirehose(firehose0: Boolean) = new OperationState {
+      type T = self.T
+      val firehose = firehose0
+      val observer = self.observer
+      val promise = self.promise
+    }
+
     def withObserver(observer0: Observer[T]) = new OperationState {
       type T = self.T
-      val bracketed = self.bracketed
+      val firehose = self.firehose
       val observer = observer0
       val promise = self.promise
     }
@@ -88,12 +97,19 @@ object System {
       case Observer.More(step, finish) => msg match {
         case msg: Prover.Protocol_Output =>
           msg.properties match {
-            case System.Libisabelle_Response(id1) if id == id1 =>
-              val xml = YXML.parse(msg.text)
-              withObserver(finish(xml))
+            case Output.Response(id1) if id == id1 =>
+              withObserver(finish(YXML.parse(msg.text)))
+            case Output.Start(id1) if id == id1 && !firehose =>
+              withFirehose(true)
+            case Output.Stop(id1) if id == id1 && firehose =>
+              withFirehose(false)
+            case _ if firehose =>
+              withObserver(step(msg))
             case _ =>
               this
           }
+        case _ if firehose =>
+          withObserver(step(msg))
         case _ =>
           this
       }
@@ -106,7 +122,7 @@ object System {
   private def mkOperationState[T0](observer0: Observer[T0]) = {
     val state = new OperationState {
       type T = T0
-      val bracketed = false
+      val firehose = false
       val observer = observer0
       val promise = Promise[Exn.Result[T]]
     }

--- a/libisabelle/src/main/scala/japi/Operations.java
+++ b/libisabelle/src/main/scala/japi/Operations.java
@@ -7,7 +7,7 @@ public class Operations {
   private Operations() {}
 
   public static <I, O> Operation<I, O> fromCodecs(String name, Codec<I> enc, Codec<O> dec) {
-    return new Operation<I, O>(name, enc, dec);
+    return Operation$.MODULE$.simple(name, enc, dec);
   }
 
   public static final Operation<String, String> HELLO =

--- a/libisabelle/src/main/scala/japi/System.scala
+++ b/libisabelle/src/main/scala/japi/System.scala
@@ -33,9 +33,6 @@ class JSystem private(system: System, timeout: Duration) {
     await(system.dispose)
 
   def invoke[I, O](operation: Operation[I, O], arg: I): O =
-    await(system.invoke(operation)(arg)) match {
-      case Left((msg, body)) => throw System.ProverException(msg, body)
-      case Right(v) => v
-    }
+    Exn.release(await(system.invoke(operation)(arg)))
 
 }

--- a/libisabelle/src/main/scala/package.scala
+++ b/libisabelle/src/main/scala/package.scala
@@ -4,6 +4,8 @@ import scala.concurrent.ExecutionContext
 
 import isabelle.XML
 
+case class DecodingException(msg: String, body: XML.Body) extends RuntimeException(msg)
+
 object defaults {
   implicit lazy val isabelleExecutionContext: ExecutionContext =
     isabelle.Future.execution_context

--- a/libisabelle/src/test/scala/IsabelleMatchers.scala
+++ b/libisabelle/src/test/scala/IsabelleMatchers.scala
@@ -1,0 +1,15 @@
+package edu.tum.cs.isabelle
+
+import org.specs2.matcher._
+
+import isabelle.Exn
+
+trait IsabelleMatchers {
+
+  def beRes[A](check: ValueCheck[A]): Matcher[Exn.Result[A]] =
+    new OptionLikeCheckedMatcher[Exn.Result, A, A]("Exn.Res", {
+      case Exn.Res(a) => Some(a)
+      case _ => None
+    }, check)
+
+}

--- a/libisabelle/src/test/scala/LibisabelleSpec.scala
+++ b/libisabelle/src/test/scala/LibisabelleSpec.scala
@@ -4,12 +4,12 @@ import scala.concurrent.duration._
 
 import edu.tum.cs.isabelle.defaults._
 
-import isabelle.XML
+import isabelle.Exn
 
 import org.specs2.Specification
 import org.specs2.matcher.Matcher
 
-class LibisabelleSpec extends Specification { def is = s2"""
+class LibisabelleSpec extends Specification with IsabelleMatchers { def is = s2"""
 
   Basic protocol interaction
 
@@ -29,10 +29,9 @@ class LibisabelleSpec extends Specification { def is = s2"""
 
   def exist[A]: Matcher[A] = ((a: A) => a != null, "doesn't exist")
 
-
   def start = system must exist.awaitFor(30.seconds)
   def load = loaded must exist.awaitFor(30.seconds)
-  def req = response must beRight("prop => prop => prop").awaitFor(30.seconds)
+  def req = response must beRes("prop => prop => prop").awaitFor(30.seconds)
   def stop = teardown must exist.awaitFor(30.seconds)
 
 }


### PR DESCRIPTION
Introduces the operation flags `sequential` and `bracket`, and generalizes operations on the Scala side to use iteratees.

`sequential` operations will be executed sequentially on the prover (that is, only one operation of one kind may be active at a time; however, other operations may be active). (Future work: `exclusive`)

`bracket` operations send an additional `start` and `end` message before and after execution, respectively. When the consumer receives a `start` message, the operation iteratee will be fed all messages from the prover, not just those related to the command.

All this has been implemented to read markup produced by `use_thys`. The Scala side now receives the markup, but doesn't do anything with it yet.
