### PR TITLE
use consistent execution contexts

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,0 +1,14 @@
+*** Portions based on code by Viktor Klang ***
+*** Source: <https://gist.github.com/viktorklang/5245161> ***
+*** Original copyright notice follows ***
+
+Copyright 2013 Viktor Klang
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pide/2015/src/main/scala/Concurrent/future.scala
+++ b/pide/2015/src/main/scala/Concurrent/future.scala
@@ -10,15 +10,14 @@ package isabelle
 
 
 import scala.util.{Success, Failure}
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor,
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService,
   Future => Scala_Future, Promise => Scala_Promise, Await}
 import scala.concurrent.duration.Duration
 
 
 object Future
 {
-  lazy val execution_context: ExecutionContextExecutor =
-    ExecutionContext.fromExecutorService(Simple_Thread.default_pool)
+  var execution_context: ExecutionContextExecutorService = null
 
   def value[A](x: A): Future[A] = new Finished_Future(x)
 

--- a/pide/2015/src/main/scala/Concurrent/par_list.scala
+++ b/pide/2015/src/main/scala/Concurrent/par_list.scala
@@ -45,7 +45,8 @@ object Par_List
     }
 
   def map[A, B](f: A => B, xs: List[A]): List[B] =
-    Exn.release_first(managed_results(f, xs))
+    xs.map(f)
+    //Exn.release_first(managed_results(f, xs))
 
   def get_some[A, B](f: A => Option[B], xs: List[A]): Option[B] =
   {

--- a/pide/2015/src/main/scala/Concurrent/simple_thread.scala
+++ b/pide/2015/src/main/scala/Concurrent/simple_thread.scala
@@ -9,8 +9,7 @@ package isabelle
 
 
 import java.lang.Thread
-import java.util.concurrent.{Callable, Future => JFuture, ThreadPoolExecutor,
-  TimeUnit, LinkedBlockingQueue}
+import java.util.concurrent.{Callable, Future => JFuture, TimeUnit, LinkedBlockingQueue}
 
 
 object Simple_Thread
@@ -40,15 +39,8 @@ object Simple_Thread
 
   /* thread pool */
 
-  lazy val default_pool =
-    {
-      val m = Properties.Value.Int.unapply(System.getProperty("isabelle.threads", "0")) getOrElse 0
-      val n = if (m > 0) m else (Runtime.getRuntime.availableProcessors max 1) min 8
-      new ThreadPoolExecutor(n, n, 2500L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue[Runnable])
-    }
-
   def submit_task[A](body: => A): JFuture[A] =
-    default_pool.submit(new Callable[A] { def call = body })
+    Future.execution_context.submit(new Callable[A] { def call = body })
 
 
   /* delayed events */

--- a/pide/2016/src/main/scala/Concurrent/standard_thread.scala
+++ b/pide/2016/src/main/scala/Concurrent/standard_thread.scala
@@ -9,7 +9,7 @@ package isabelle
 
 
 import java.lang.Thread
-import java.util.concurrent.{ThreadPoolExecutor, TimeUnit, LinkedBlockingQueue, ThreadFactory}
+import java.util.concurrent.{ExecutorService, TimeUnit, LinkedBlockingQueue, ThreadFactory}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -31,27 +31,7 @@ object Standard_Thread
 
   /* pool */
 
-  lazy val pool: ThreadPoolExecutor =
-    {
-      val m = Properties.Value.Int.unapply(System.getProperty("isabelle.threads", "0")) getOrElse 0
-      val n = if (m > 0) m else (Runtime.getRuntime.availableProcessors max 1) min 8
-      val executor =
-        new ThreadPoolExecutor(n, n, 2500L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue[Runnable])
-      val old_thread_factory = executor.getThreadFactory
-      executor.setThreadFactory(
-        new ThreadFactory {
-          def newThread(r: Runnable) =
-          {
-            val thread = old_thread_factory.newThread(r)
-            thread.setDaemon(true)
-            thread
-          }
-        })
-      executor
-    }
-
-  lazy val execution_context: ExecutionContextExecutor =
-    ExecutionContext.fromExecutorService(pool)
+  var pool: ExecutorService = null
 
 
   /* delayed events */

--- a/pide/2016/src/main/scala/impl/Environment.scala
+++ b/pide/2016/src/main/scala/impl/Environment.scala
@@ -11,8 +11,9 @@ import shapeless._
 import shapeless.tag._
 
 @api.Implementation(identifier = "2016")
-final class Environment private(home: Path) extends api.Environment(home) {
+final class Environment private(context: api.Environment.Context) extends api.Environment(context) {
 
+	isabelle.Standard_Thread.pool = context.executorService
   isabelle.Isabelle_System.init(
     isabelle_root = home.toAbsolutePath.toString,
     cygwin_root = home.resolve("contrib/cygwin").toAbsolutePath.toString
@@ -27,9 +28,6 @@ final class Environment private(home: Path) extends api.Environment(home) {
   protected[isabelle] val functionTag = isabelle.Markup.FUNCTION
   protected[isabelle] val initTag = isabelle.Markup.INIT
   protected[isabelle] val protocolTag = isabelle.Markup.PROTOCOL
-
-  lazy val executionContext =
-    isabelle.Standard_Thread.execution_context
 
   protected[isabelle] type Session = isabelle.Session
 
@@ -83,11 +81,6 @@ final class Environment private(home: Path) extends api.Environment(home) {
     session.protocol_command("Prover.options", isabelle.YXML.string_of_body(options.encode))
 
   protected[isabelle] def dispose(session: Session) = session.stop()
-
-  protected[isabelle] def destroy(): Unit = {
-    isabelle.Standard_Thread.pool.shutdownNow()
-    ()
-  }
 
   def decode(text: String @@ api.Environment.Raw): String @@ api.Environment.Unicode = tag.apply(isabelle.Symbol.decode(text))
   def encode(text: String @@ api.Environment.Unicode): String @@ api.Environment.Raw = tag.apply(isabelle.Symbol.encode(text))

--- a/tests/src/test/scala/EnvironmentSpec.scala
+++ b/tests/src/test/scala/EnvironmentSpec.scala
@@ -26,12 +26,12 @@ class EnvironmentSpec(val specs2Env: Env) extends Specification with DefaultSetu
   val context = Thread.currentThread.getContextClassLoader
   val constructor = Setup.fetchImplementation(platform, version).map { paths =>
     val clazz = new URLClassLoader(paths.map(_.toUri.toURL).toArray, context).loadClass(s"${Setup.defaultPackageName}.Environment")
-    val constructor = clazz.getDeclaredConstructor(classOf[Path])
+    val constructor = clazz.getDeclaredConstructor(classOf[Environment.Context])
     constructor.setAccessible(true)
     constructor
   }
 
-  def instantiate(home: Path) = constructor.map(_.newInstance(home))
+  def instantiate(home: Path) = constructor.map(_.newInstance(Environment.Context(home, implicitly)))
 
   val first = instantiate(platform.setupStorage(version))
 


### PR DESCRIPTION
Closes #14.

This replaces the internal PIDE `ExecutionContextExecutorService` by the implicitly-available `ExecutionContext` when instantiating the environment.

For some odd reason `Par_List.map` in PIDE 2015 leads to a deadlock under Windows. Hence, d689235 disables the parallelism in that operation (everywhere, not just on Windows). A quick search over the sources doesn't reveal any potential major performance degradation.
