### PR TITLE
No more `publishLocal`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 os:
   - osx
 script:
-  - ./sbt "++$SCALA_VERSION" publishLocal
+  - ./sbt "++$SCALA_VERSION" compile
   - ./sbt "++$SCALA_VERSION" "cli/run --version $ISABELLE_VERSION build"
   - ./sbt "++$SCALA_VERSION" test
 matrix:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ To get started, follow these steps:
 2. Run the `sbt` script to fetch all required Scala dependencies.
    After this is done, you are in the SBT shell.
 3. Compile the sources with `compile`.
-4. If you have used an arbitrary snapshot of the sources (e.g. via `git clone`), run `publishLocal`.
-5. Bootstrap an Isabelle installation using `cli/run --version 2016 build`, which will download and extract the latest supported Isabelle version for you.
+4. Bootstrap an Isabelle installation using `cli/run --version 2016 build`, which will download and extract the latest supported Isabelle version for you.
 
 On some systems, you might need to install Perl, Python, and/or some additional libraries.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,6 @@ environment:
   matrix:
     - ISABELLE_VERSION: 2016
 build_script:
-  - sbt publishLocal
+  - sbt compile
 test_script:
   - sbt "cli/run --version %ISABELLE_VERSION% build"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ lazy val standardSettings = Seq(
   ),
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  libraryDependencies += "org.log4s" %% "log4s" % "1.2.1",
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (version.value.endsWith("SNAPSHOT"))
@@ -110,7 +109,10 @@ lazy val pideInterface = project.in(file("pide-interface"))
   .settings(
     buildInfoKeys := apiBuildInfoKeys,
     buildInfoPackage := "edu.tum.cs.isabelle.api",
-    libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.0"
+    libraryDependencies ++= Seq(
+      "com.chuusai" %% "shapeless" % "2.3.0",
+      "org.log4s" %% "log4s" % "1.2.1"
+    )
   )
 
 lazy val libisabelle = project
@@ -163,7 +165,7 @@ lazy val tests = project.in(file("tests"))
 // PIDE implementations
 
 def pide(version: String) = Project(s"pide$version", file(s"pide/$version"))
-  .dependsOn(pideInterface)
+  .dependsOn(pideInterface % "provided")
   .settings(moduleName := s"pide-$version")
   .settings(standardSettings)
   .enablePlugins(GitVersioning, BuildInfoPlugin)

--- a/pide/2015/src/main/scala/impl/Environment.scala
+++ b/pide/2015/src/main/scala/impl/Environment.scala
@@ -13,7 +13,7 @@ import shapeless.tag._
 @api.Implementation(identifier = "2015")
 final class Environment private(context: api.Environment.Context) extends api.Environment(context) {
 
-	isabelle.Future.execution_context = context.executorService
+  isabelle.Future.execution_context = context.executorService
   isabelle.Isabelle_System.init(
     isabelle_home = home.toAbsolutePath.toString,
     cygwin_root = home.resolve("contrib/cygwin").toAbsolutePath.toString

--- a/pide/2016/src/main/scala/impl/Environment.scala
+++ b/pide/2016/src/main/scala/impl/Environment.scala
@@ -13,7 +13,7 @@ import shapeless.tag._
 @api.Implementation(identifier = "2016")
 final class Environment private(context: api.Environment.Context) extends api.Environment(context) {
 
-	isabelle.Standard_Thread.pool = context.executorService
+  isabelle.Standard_Thread.pool = context.executorService
   isabelle.Isabelle_System.init(
     isabelle_root = home.toAbsolutePath.toString,
     cygwin_root = home.resolve("contrib/cygwin").toAbsolutePath.toString

--- a/setup/src/main/scala/Resolver.scala
+++ b/setup/src/main/scala/Resolver.scala
@@ -1,0 +1,124 @@
+package edu.tum.cs.isabelle.setup
+
+import java.io.{File, FileNotFoundException}
+import java.nio.file._
+import java.net.URL
+
+import scala.concurrent.{Future, ExecutionContext}
+
+import org.apache.commons.io.IOUtils
+
+import coursier._
+
+import org.log4s._
+
+import edu.tum.cs.isabelle.api.{BuildInfo, Version}
+
+import acyclic.file
+
+trait Resolver { self =>
+
+  def resolve(platform: Platform, version: Version)(implicit ec: ExecutionContext): Future[List[Path]]
+
+  def orElse(that: Resolver) = new Resolver {
+    def resolve(platform: Platform, version: Version)(implicit ec: ExecutionContext) =
+      // recoverWith instead of fallbackTo because the latter is eager
+      // we don't want to run the second future unless necessary
+      self.resolve(platform, version).recoverWith { case _ => that.resolve(platform, version) }
+  }
+
+}
+
+object Resolver {
+
+  def Default =
+    Classpath orElse Maven
+
+
+  object Classpath extends Resolver {
+
+    private val logger = getLogger
+
+    def resolve(platform: Platform, version: Version)(implicit ec: ExecutionContext) = {
+      val classLoader = getClass.getClassLoader
+      val fileName = s"pide-${version.identifier}-assembly.jar"
+      Option(classLoader.getResourceAsStream(fileName)) match {
+        case Some(stream) =>
+          val target = Files.createTempFile("pide", ".jar")
+          logger.debug(s"Dumping PIDE jar to $target ...")
+          IOUtils.copy(stream, Files.newOutputStream(target, StandardOpenOption.WRITE))
+          Future.successful { List(target) }
+        case None =>
+          Future.failed { new FileNotFoundException(s"PIDE ${version.identifier} not on classpath") }
+      }
+    }
+
+  }
+
+  object Maven extends Resolver {
+
+    private val logger = getLogger
+
+    def resolve(platform: Platform, version: Version)(implicit ec: ExecutionContext) = {
+      val base = platform.versionedStorage
+
+      val repositories = Seq(
+        coursier.Cache.ivy2Local,
+        MavenRepository("https://repo1.maven.org/maven2"),
+        MavenRepository("https://oss.sonatype.org/content/repositories/releases")
+      )
+
+      val downloadLogger = new coursier.Cache.Logger {
+        override def downloadingArtifact(url: String, file: File) =
+          logger.debug(s"Downloading artifact from $url ...")
+        override def downloadedArtifact(url: String, success: Boolean) = {
+          val file = url.split('/').last
+          if (success)
+            logger.debug(s"Successfully downloaded $file")
+          else
+            logger.error(s"Failed to download $file")
+        }
+      }
+
+      val fetch = Fetch.from(
+        repositories,
+        Cache.fetch(logger = Some(downloadLogger), cachePolicy = CachePolicy.LocalOnly),
+        Cache.fetch(logger = Some(downloadLogger), cachePolicy = CachePolicy.FetchMissing)
+      )
+
+      val dependency =
+        Dependency(
+          Module(BuildInfo.organization, s"pide-${version.identifier}_${BuildInfo.scalaBinaryVersion}"),
+          BuildInfo.version
+        )
+
+      def fetchArtifact(artifact: Artifact, cachePolicy: CachePolicy) =
+        Cache.file(artifact, logger = Some(downloadLogger), cachePolicy = cachePolicy)
+
+      platform.withAsyncLock { () =>
+        for {
+          resolution <- Resolution(Set(dependency)).process.run(fetch).toScalaFuture
+          artifacts = {
+              if (!resolution.isDone)
+                sys.error("not converged")
+              else if (!resolution.errors.isEmpty)
+                sys.error(s"errors: ${resolution.errors}")
+              else if (!resolution.conflicts.isEmpty)
+                sys.error(s"conflicts: ${resolution.conflicts}")
+              else
+                resolution.artifacts.toSet
+            }
+          res <- Future.traverse(artifacts.toList)(artifact =>
+            (fetchArtifact(artifact, CachePolicy.LocalOnly)
+               orElse fetchArtifact(artifact, CachePolicy.FetchMissing))
+              .run.toScalaFuture
+          )
+        }
+        yield
+          res.map(_.fold(err => sys.error(err.toString), _.toPath))
+      }
+    }
+
+  }
+
+}

--- a/setup/src/main/scala/Resources.scala
+++ b/setup/src/main/scala/Resources.scala
@@ -10,7 +10,7 @@ import org.apache.commons.io.IOUtils
 
 import org.log4s._
 
-import edu.tum.cs.isabelle.api.Configuration
+import edu.tum.cs.isabelle.api.{Configuration, Version}
 
 import acyclic.file
 

--- a/setup/src/main/scala/Setup.scala
+++ b/setup/src/main/scala/Setup.scala
@@ -9,8 +9,6 @@ import scala.util._
 
 import cats.data.Xor
 
-import coursier._
-
 import org.log4s._
 
 import edu.tum.cs.isabelle.api.{BuildInfo, Environment, Version}
@@ -108,65 +106,6 @@ object Setup {
         }
     }
 
-  def fetchImplementation(platform: Platform, version: Version)(implicit ec: ExecutionContext): Future[List[Path]] = {
-    val base = platform.versionedStorage
-
-    val repositories = Seq(
-      coursier.Cache.ivy2Local,
-      MavenRepository("https://repo1.maven.org/maven2"),
-      MavenRepository("https://oss.sonatype.org/content/repositories/releases")
-    )
-
-    val downloadLogger = new coursier.Cache.Logger {
-      override def downloadingArtifact(url: String, file: File) =
-        logger.debug(s"Downloading artifact from $url ...")
-      override def downloadedArtifact(url: String, success: Boolean) = {
-        val file = url.split('/').last
-        if (success)
-          logger.debug(s"Successfully downloaded $file")
-        else
-          logger.error(s"Failed to download $file")
-      }
-    }
-
-    val fetch = Fetch.from(
-      repositories,
-      Cache.fetch(logger = Some(downloadLogger), cachePolicy = CachePolicy.LocalOnly),
-      Cache.fetch(logger = Some(downloadLogger), cachePolicy = CachePolicy.FetchMissing)
-    )
-
-    val dependency =
-      Dependency(
-        Module(BuildInfo.organization, s"pide-${version.identifier}_${BuildInfo.scalaBinaryVersion}"),
-        BuildInfo.version
-      )
-
-    def fetchArtifact(artifact: Artifact, cachePolicy: CachePolicy) =
-      Cache.file(artifact, logger = Some(downloadLogger), cachePolicy = cachePolicy)
-
-    platform.withAsyncLock { () =>
-      for {
-        resolution <- Resolution(Set(dependency)).process.run(fetch).toScalaFuture
-        artifacts = {
-            if (!resolution.isDone)
-              sys.error("not converged")
-            else if (!resolution.errors.isEmpty)
-              sys.error(s"errors: ${resolution.errors}")
-            else if (!resolution.conflicts.isEmpty)
-              sys.error(s"conflicts: ${resolution.conflicts}")
-            else
-              resolution.artifacts.toSet
-          }
-        res <- Future.traverse(artifacts.toList)(artifact =>
-          (fetchArtifact(artifact, CachePolicy.LocalOnly)
-             orElse fetchArtifact(artifact, CachePolicy.FetchMissing))
-            .run.toScalaFuture
-        )
-      }
-      yield
-        res.map(_.fold(err => sys.error(err.toString), _.toPath))
-    }
-  }
 
 }
 
@@ -206,13 +145,16 @@ final case class Setup(home: Path, platform: Platform, version: Version, package
     constructor.newInstance(context)
   }
 
+  def makeEnvironment(implicit ec: ExecutionContext): Future[Environment] =
+    makeEnvironment(Resolver.Default)
+
   /**
    * Prepares a fresh [[edu.tum.cs.isabelle.api.Environment]].
    *
-   * Uses [[Setup.fetchImplementation]] to download the required classpath. It
+   * If the [[Resolver resolver]] found an appropriate classpath, this method
    * also checks for matching [[edu.tum.cs.isabelle.api.BuildInfo build info]].
    */
-  def makeEnvironment(implicit ec: ExecutionContext): Future[Environment] =
-    Setup.fetchImplementation(platform, version).map(paths => instantiate(paths.map(_.toUri.toURL)))
+  def makeEnvironment(resolver: Resolver)(implicit ec: ExecutionContext): Future[Environment] =
+    resolver.resolve(platform, version).map(paths => instantiate(paths.map(_.toUri.toURL)))
 
 }

--- a/tests/src/test/scala/EnvironmentSpec.scala
+++ b/tests/src/test/scala/EnvironmentSpec.scala
@@ -10,7 +10,7 @@ import org.specs2.specification.core.Env
 
 import edu.tum.cs.isabelle._
 import edu.tum.cs.isabelle.api._
-import edu.tum.cs.isabelle.setup.Setup
+import edu.tum.cs.isabelle.setup.{Resolver, Setup}
 
 class EnvironmentSpec(val specs2Env: Env) extends Specification with DefaultSetup with IsabelleMatchers { def is = s2"""
 
@@ -24,7 +24,7 @@ class EnvironmentSpec(val specs2Env: Env) extends Specification with DefaultSetu
   // FIXME code duplication
 
   val context = Thread.currentThread.getContextClassLoader
-  val constructor = Setup.fetchImplementation(platform, version).map { paths =>
+  val constructor = Resolver.Default.resolve(platform, version).map { paths =>
     val clazz = new URLClassLoader(paths.map(_.toUri.toURL).toArray, context).loadClass(s"${Setup.defaultPackageName}.Environment")
     val constructor = clazz.getDeclaredConstructor(classOf[Environment.Context])
     constructor.setAccessible(true)


### PR DESCRIPTION
PIDE implementations may be resolved from the classpath
- resolver: abstraction over finding PIDE implementations
- coursier-based resolver is maintained
- new classpath-based resolver looks up JAR from classpath
- build: `pide-package` module bundles PIDE implementations as resources
