### PR TITLE
carefully inject additional environment variables

### DIFF
--- a/modules/pide/2015/src/main/scala/System/isabelle_system.scala
+++ b/modules/pide/2015/src/main/scala/System/isabelle_system.scala
@@ -63,7 +63,7 @@ object Isabelle_System
       (2) ISABELLE_HOME process environment variable (e.g. inherited from running isabelle tool)
       (3) isabelle.home system property (e.g. via JVM application boot process)
   */
-  def init(isabelle_home: String = "", cygwin_root: String = ""): Unit = synchronized {
+  def init(isabelle_home: String = "", cygwin_root: String = "", user: String = "", init_env: Map[String, String] = Map.empty): Unit = synchronized {
     if (_settings.isEmpty) {
       import scala.collection.JavaConversions._
 
@@ -92,11 +92,13 @@ object Isabelle_System
 
         default(
           default(
-            default(sys.env + ("ISABELLE_JDK_HOME" -> posix_path(jdk_home())),
-              "TEMP_WINDOWS" -> temp_windows),
-            "HOME" -> user_home),
-          "ISABELLE_APP" -> "true")
-      }
+            default(
+              default(sys.env + ("ISABELLE_JDK_HOME" -> posix_path(jdk_home())),
+                "TEMP_WINDOWS" -> temp_windows),
+              "HOME" -> user_home),
+            "ISABELLE_APP" -> "true"),
+          "USER_HOME" -> posix_path(user))
+      } ++ init_env
 
       val system_home =
         if (isabelle_home != null && isabelle_home != "") isabelle_home

--- a/modules/pide/2015/src/main/scala/impl/Environment.scala
+++ b/modules/pide/2015/src/main/scala/impl/Environment.scala
@@ -16,10 +16,10 @@ final class Environment private(context: api.Environment.Context) extends api.En
   isabelle.Future.execution_context = context.executorService
   isabelle.Isabelle_System.init(
     isabelle_home = home.toString,
-    cygwin_root = home.resolve("contrib/cygwin").toAbsolutePath.toString
+    cygwin_root = home.resolve("contrib/cygwin").toString,
+    user = user.toString,
+    init_env = variables
   )
-
-  api.Environment.patchSettings(isabelle.Isabelle_System, variables)
 
   private def destMarkup(markup: isabelle.Markup) =
     (markup.name, markup.properties)
@@ -32,6 +32,9 @@ final class Environment private(context: api.Environment.Context) extends api.En
   protected[isabelle] type Session = isabelle.Session
 
   private lazy val options = isabelle.Options.init()
+
+  protected[isabelle] def isabelleSetting(name: String): String =
+    isabelle.Isabelle_System.getenv(name)
 
   protected[isabelle] def isabellePath(path: String): String =
     isabelle.Isabelle_System.posix_path(path)

--- a/modules/pide/2016/src/main/scala/System/isabelle_system.scala
+++ b/modules/pide/2016/src/main/scala/System/isabelle_system.scala
@@ -57,7 +57,7 @@ object Isabelle_System
     _settings.get
   }
 
-  def init(isabelle_root: String = "", cygwin_root: String = ""): Unit = synchronized {
+  def init(isabelle_root: String = "", cygwin_root: String = "", user: String = "", init_env: Map[String, String] = Map.empty): Unit = synchronized {
     if (_settings.isEmpty) {
       import scala.collection.JavaConversions._
 
@@ -95,11 +95,13 @@ object Isabelle_System
 
         default(
           default(
-            default(sys.env + ("ISABELLE_JDK_HOME" -> File.standard_path(jdk_home())),
-              "TEMP_WINDOWS" -> temp_windows),
-            "HOME" -> user_home),
-          "ISABELLE_APP" -> "true")
-      }
+            default(
+              default(sys.env + ("ISABELLE_JDK_HOME" -> File.standard_path(jdk_home())),
+                "TEMP_WINDOWS" -> temp_windows),
+              "HOME" -> user_home),
+            "ISABELLE_APP" -> "true"),
+          "USER_HOME" -> File.standard_path(user))
+      } ++ init_env
 
       val settings =
       {

--- a/modules/pide/2016/src/main/scala/impl/Environment.scala
+++ b/modules/pide/2016/src/main/scala/impl/Environment.scala
@@ -15,11 +15,11 @@ final class Environment private(context: api.Environment.Context) extends api.En
 
   isabelle.Standard_Thread.pool = context.executorService
   isabelle.Isabelle_System.init(
-    isabelle_root = home.toAbsolutePath.toString,
-    cygwin_root = home.resolve("contrib/cygwin").toAbsolutePath.toString
+    isabelle_root = home.toString,
+    cygwin_root = home.resolve("contrib/cygwin").toString,
+    user = user.toString,
+    init_env = variables
   )
-
-  api.Environment.patchSettings(isabelle.Isabelle_System, variables)
 
   private def destMarkup(markup: isabelle.Markup) =
     (markup.name, markup.properties)
@@ -32,6 +32,9 @@ final class Environment private(context: api.Environment.Context) extends api.En
   protected[isabelle] type Session = isabelle.Session
 
   private lazy val options = isabelle.Options.init()
+
+  protected[isabelle] def isabelleSetting(name: String): String =
+    isabelle.Isabelle_System.getenv(name)
 
   protected[isabelle] def isabellePath(path: String): String =
     isabelle.File.standard_path(path)

--- a/modules/setup/src/main/scala/Setup.scala
+++ b/modules/setup/src/main/scala/Setup.scala
@@ -156,7 +156,7 @@ final case class Setup(home: Path, platform: Platform, version: Version, package
       sys.error(s"build info does not match")
 
     val constructor = env.getDeclaredConstructor(classOf[Environment.Context])
-    val context = Environment.Context(home, ec, user)
+    val context = Environment.Context(home, user)(ec)
     constructor.setAccessible(true)
     constructor.newInstance(context)
   }

--- a/tests/offline/src/test/scala/EnvironmentSpec.scala
+++ b/tests/offline/src/test/scala/EnvironmentSpec.scala
@@ -1,8 +1,10 @@
 package info.hupel.isabelle.tests
 
+import java.lang.reflect.Constructor
 import java.net.URLClassLoader
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.specs2.Specification
@@ -12,13 +14,14 @@ import info.hupel.isabelle._
 import info.hupel.isabelle.api._
 import info.hupel.isabelle.setup.{Resolver, Setup}
 
-class EnvironmentSpec(val specs2Env: Env) extends Specification with DefaultSetup with IsabelleMatchers { def is = s2"""
+class EnvironmentSpec(val specs2Env: Env) extends Specification with BasicSetup with IsabelleMatchers { def is = s2"""
 
   Environment handling
 
   A low-level environment
-    can be instantiated twice with the same path          ${same must exist.awaitFor(30.seconds)}
-    cannot be instantiated with a different path          ${diff must throwAn[Exception].awaitFor(30.seconds)}"""
+    respects the USER_HOME setting                        ${settingsPrefix must beTrue.awaitFor(duration)}
+    can be instantiated twice with the same path          ${same must exist.awaitFor(duration)}
+    cannot be instantiated with a different path          ${diff must throwAn[Exception].awaitFor(duration)}"""
 
 
   // FIXME code duplication
@@ -28,25 +31,23 @@ class EnvironmentSpec(val specs2Env: Env) extends Specification with DefaultSetu
     val clazz = new URLClassLoader(paths.map(_.toUri.toURL).toArray, context).loadClass(s"${Setup.defaultPackageName}.Environment")
     val constructor = clazz.getDeclaredConstructor(classOf[Environment.Context])
     constructor.setAccessible(true)
-    constructor
+    constructor.asInstanceOf[Constructor[Environment]]
   }
 
-  def instantiate(home: Path) = constructor.map(_.newInstance(Environment.Context(home, implicitly)))
+  val user = Files.createTempDirectory("libisabelle_user")
 
-  val first = instantiate(platform.setupStorage(version))
+  def instantiate(home: Path): Future[Environment] = constructor.map(_.newInstance(Environment.Context(home, user)))
 
-  val same =
-    for {
-      _ <- first
-      env2 <- instantiate(platform.setupStorage(version))
+  val first: Future[Environment] = instantiate(platform.setupStorage(version))
+
+  val settingsPrefix = first.map { env =>
+    val prefix = env.isabellePath(user.toAbsolutePath.toString)
+    List("ISABELLE_BROWSER_INFO", "ISABELLE_OUTPUT", "ISABELLE_HOME_USER").forall { setting =>
+      env.isabelleSetting(setting).startsWith(prefix)
     }
-    yield env2
+  }
 
-  val diff =
-    for {
-      _ <- first
-      env2 <- instantiate(platform.setupStorage(version).resolve("."))
-    }
-    yield env2
+  val same = first.flatMap { _ => instantiate(platform.setupStorage(version)) }
+  val diff = first.flatMap { _ => instantiate(platform.setupStorage(version).resolve(".")) }
 
 }


### PR DESCRIPTION
Gets rid of gnarly reflection, at the cost of changing PIDE sources.

Fixes #52.
