### PR TITLE
UseThy operation should observe results

### DIFF
--- a/modules/libisabelle/src/main/scala/Operation.scala
+++ b/modules/libisabelle/src/main/scala/Operation.scala
@@ -1,23 +1,9 @@
 package info.hupel.isabelle
 
-import scala.util.control.NoStackTrace
-
 import info.hupel.isabelle.api.XML
 
 /** Combinators for creating [[Operation operations]] and basic operations. */
 object Operation {
-
-  /**
-   * Slightly fishy exception to represent any kind of exception from the
-   * prover.
-   *
-   * There is no stack traces available, because instance are only created when
-   * the prover throws an exception.
-   */
-  final case class ProverException private[isabelle](operation: String, msg: String, input: Any) extends RuntimeException(msg) with NoStackTrace {
-    def fullMessage =
-      s"Prover error in operation $operation: $msg\nOffending input: $input"
-  }
 
   /** Create a [[simple]] observer using implicit [[Codec codecs]]. */
   def implicitly[I : Codec, O : Codec](name: String): Operation[I, O] =
@@ -28,35 +14,17 @@ object Operation {
    * final result and immediately attempts to decode it with a given
    * [[Codec codec]].
    */
-  def simple[I, O](name: String, toProver: Codec[I], fromProver: Codec[O]): Operation[I, O] = {
-    def exn(input: I) = Codec.text[Exception](
-      _.getMessage,
-      str => Some(ProverException(name, str, input)),
-      "exn"
-    ).tagged("exn")
-
-    def proverResult(input: I) = new Codec.Variant[ProverResult[O]]("Exn.result") {
-      val mlType = "Exn.result"
-      def enc(a: ProverResult[O]) = sys.error("impossible")
-      def dec(idx: Int) = idx match {
-        case 0 => Some(fromProver.decode(_).right.map(ProverResult.Success.apply))
-        case 1 => Some(exn(input).decode(_).right.map(ProverResult.Failure.apply))
-        case _ => None
-      }
-    }
-
-    new Operation[I, O](name) {
-      def prepare(i: I): (XML.Tree, Observer[O]) = {
-        val tree = toProver.encode(i)
-        val observer = Observer.ignoreStep[O] { tree =>
-          proverResult(i).decode(tree) match {
-            case Left((err, body)) => Observer.Failure(DecodingException(err, body))
-            case Right(o) => Observer.Success(o)
-          }
+  def simple[I, O](name: String, toProver: Codec[I], fromProver: Codec[O]): Operation[I, O] = new Operation[I, O](name) {
+    def prepare(i: I): (XML.Tree, Observer[O]) = {
+      val tree = toProver.encode(i)
+      val observer = Observer.ignoreStep[O] { tree =>
+        ProverResult.resultCodec(fromProver, name, i).decode(tree) match {
+          case Left((err, body)) => Observer.Failure(DecodingException(err, body))
+          case Right(o) => Observer.Success(o)
         }
-
-        (tree, observer)
       }
+
+      (tree, observer)
     }
   }
 
@@ -77,7 +45,13 @@ object Operation {
       val tree = Codec[List[String]].encode(args)
       def observer(a: A): Observer[B] = Observer.More(
         step = msg => observer(markup(a, msg)),
-        done = _ => Observer.Success(ProverResult.Success(finish(a)))
+        done = { tree =>
+          ProverResult.resultCodec[Unit](Codec[Unit], name, args).decode(tree) match {
+            case Left((err, body)) => Observer.Failure(DecodingException(err, body))
+            case Right(ProverResult.Success(())) => Observer.Success(ProverResult.Success(finish(a)))
+            case Right(fail @ ProverResult.Failure(_)) => Observer.Success(fail)
+          }
+        }
       )
 
       (tree, observer(init))

--- a/modules/libisabelle/src/main/scala/Operation.scala
+++ b/modules/libisabelle/src/main/scala/Operation.scala
@@ -48,8 +48,7 @@ object Operation {
         done = { tree =>
           ProverResult.resultCodec[Unit](Codec[Unit], name, args).decode(tree) match {
             case Left((err, body)) => Observer.Failure(DecodingException(err, body))
-            case Right(ProverResult.Success(())) => Observer.Success(ProverResult.Success(finish(a)))
-            case Right(fail @ ProverResult.Failure(_)) => Observer.Success(fail)
+            case Right(res) => Observer.Success(res.map { case () => finish(a) })
           }
         }
       )

--- a/modules/libisabelle/src/main/scala/japi/JSystem.scala
+++ b/modules/libisabelle/src/main/scala/japi/JSystem.scala
@@ -32,7 +32,7 @@ final class JSystem private(system: System, timeout: Duration) {
   def invoke[I, O](operation: Operation[I, O], arg: I): O =
     await(system.invoke(operation)(arg)) match {
       case ProverResult.Success(o) => o
-      case ProverResult.Failure(exn) => throw exn
+      case exn: ProverResult.Failure => throw exn
     }
 
 }

--- a/tests/offline/src/main/isabelle/Failing.thy
+++ b/tests/offline/src/main/isabelle/Failing.thy
@@ -1,0 +1,8 @@
+theory Failing
+imports Pure
+begin
+
+lemma "PROP x"
+  by -
+
+end

--- a/tests/offline/src/main/isabelle/ROOT
+++ b/tests/offline/src/main/isabelle/ROOT
@@ -1,3 +1,4 @@
 session Unbuilt_Session = Protocol +
   theories
     Sleepy
+    Failing

--- a/tests/offline/src/main/scala/IsabelleMatchers.scala
+++ b/tests/offline/src/main/scala/IsabelleMatchers.scala
@@ -12,11 +12,11 @@ trait IsabelleMatchers { self: Matchers =>
       case _ => None
     }, check)
 
-  def beFailure[A]: Matcher[ProverResult[A]] =
-    new OptionLikeMatcher[ProverResult, A, Exception]("ProverResult.Failure", {
-      case ProverResult.Failure(exn) => Some(exn)
+  def beFailure[A](check: ValueCheck[String]): Matcher[ProverResult[A]] =
+    new OptionLikeCheckedMatcher[ProverResult, A, String]("ProverResult.Failure", {
+      case ProverResult.Failure(_, msg, _) => Some(msg)
       case _ => None
-    })
+    }, check)
 
   def exist[A]: Matcher[A] = ((a: A) => a != null, "doesn't exist")
 

--- a/tests/pure/src/test/scala/LibisabelleSpec.scala
+++ b/tests/pure/src/test/scala/LibisabelleSpec.scala
@@ -27,9 +27,10 @@ abstract class LibisabelleSpec(val specs2Env: Env, flavour: String) extends Spec
     supports term parsing      ${parseCheck must beSuccess(Option.empty[String]).awaitFor(duration)}
     can parse terms            ${parsed must beSome.awaitFor(duration)}
     can't parse wrong terms    ${parseFailed must beNone.awaitFor(duration)}
-    handles missing operations ${missingOperation must beFailure.awaitFor(duration)}
+    handles missing operations ${missingOperation must beFailure(contain("unknown command")).awaitFor(duration)}
     can load theories          ${loaded must beSuccess(()).awaitFor(duration)}
-    handles operation errors   ${operationError must beFailure.awaitFor(duration)}
+    handles operation errors   ${operationError must beFailure(contain("Invalid time")).awaitFor(duration)}
+    handles load errors        ${loadedFailing must beFailure(contain("Failed to finish proof")).awaitFor(duration)}
     can cancel requests        ${cancelled.failed must beAnInstanceOf[CancellationException].awaitFor(duration)}"""
 
 
@@ -62,6 +63,7 @@ abstract class LibisabelleSpec(val specs2Env: Env, flavour: String) extends Spec
   }
 
   val loaded = load("Sleepy")
+  val loadedFailing = load("Failing")
 
   val Sleepy = Operation.implicitly[BigInt, Unit]("sleepy")
 

--- a/tests/pure/src/test/scala/LibisabelleSpec.scala
+++ b/tests/pure/src/test/scala/LibisabelleSpec.scala
@@ -51,7 +51,17 @@ abstract class LibisabelleSpec(val specs2Env: Env, flavour: String) extends Spec
 
   // Loading auxiliary files
 
-  val loaded = system.flatMap(_.invoke(Operation.UseThys)(List(resources.findTheory(Paths.get("tests/Sleepy.thy")).get)))
+  def load(name: String) = {
+    val thy = resources.findTheory(Paths.get(s"tests/$name.thy")).get
+    for {
+      s <- system
+      e <- isabelleEnv
+      res <- s.invoke(Operation.UseThys)(List(e.isabellePath(thy)))
+    }
+    yield res
+  }
+
+  val loaded = load("Sleepy")
 
   val Sleepy = Operation.implicitly[BigInt, Unit]("sleepy")
 


### PR DESCRIPTION
Previously, `Operation.UseThy` would consume markup, but strangely did not observe the final result. This means that errors in theories may not propagate properly. This commit makes UseThy fail accordingly.

@dominique-unruh, this should fix your issue. I will add some tests for this too, but please try it out.